### PR TITLE
Adaptações para execução no ambiente AWS/ECS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . /middleware-site
 RUN pip install -r requirements.txt
 
 # Expõe a porta do servidor Flask
-EXPOSE 5000
+EXPOSE 8080
 
 # Comando para rodar o servidor
 CMD ["python", "middleware.py"]

--- a/aws/aws.env
+++ b/aws/aws.env
@@ -1,0 +1,6 @@
+# Variáveis usadas nas chamadas às APIs da AWS
+ECR_REGION=sa-east-1
+ECR_URI=279634266618.dkr.ecr.sa-east-1.amazonaws.com
+ECR_REPO=lucas-santana/middleware
+ECR_REPO_URI=${ECR_URI}/${ECR_REPO}
+TAGS="v0.0.1 latest"

--- a/aws/middleware.json
+++ b/aws/middleware.json
@@ -1,0 +1,54 @@
+{
+    "family": "lucas-santana-middleware",
+    "containerDefinitions": [
+        {
+            "name": "lucas-santana-middleware",
+            "image": "279634266618.dkr.ecr.sa-east-1.amazonaws.com/lucas-santana/middleware:latest",
+            "cpu": 128,
+            "memory": 128,
+            "memoryReservation": 64,
+            "portMappings": [
+                {
+                    "name": "lucas-santana-middleware-8080-tcp",
+                    "containerPort": 8080,
+                    "hostPort": 0,
+                    "protocol": "tcp",
+                    "appProtocol": "http"
+                }
+            ],
+            "essential": true,
+            "environment": [],
+            "mountPoints": [],
+            "volumesFrom": [],
+            "secrets": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-create-group": "true",
+                    "awslogs-group": "/utfpr/ecs/lucas-santana-middleware",
+                    "awslogs-region": "sa-east-1",
+                    "awslogs-stream-prefix": "ecs"
+                },
+                "secretOptions": []
+            },
+            "systemControls": []
+        }
+    ],
+    "taskRoleArn": "arn:aws:iam::279634266618:role/ecsTaskExecutionRole",
+    "executionRoleArn": "arn:aws:iam::279634266618:role/ecsTaskExecutionRole",
+    "networkMode": "bridge",
+    "volumes": [],
+    "requiresCompatibilities": [
+        "EC2"
+    ],
+    "runtimePlatform": {
+        "cpuArchitecture": "ARM64",
+        "operatingSystemFamily": "LINUX"
+    },
+    "tags": [
+        {
+            "key": "utfpr-depto",
+            "value": "DAINF-CT"
+        }
+    ]
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,15 @@
+source aws/aws.env
+
+# Cria a imagem localmente
+docker compose build
+
+# Autentica no ECR
+aws ecr get-login-password --region ${ECR_REGION} | docker login --username AWS --password-stdin ${ECR_URI}
+
+# Aplca tags à imagem
+for t in ${TAGS}; do
+    docker tag ${ECR_REPO} ${ECR_REPO_URI}:${t}
+done
+
+# Envia imagem para o ECR
+docker push --all-tags ${ECR_REPO_URI}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
-version: "3"
 services:
   flask-app:
-    build: .
+    container_name: lucas-santana-middleware
+    image: lucas-santana/middleware:latest
+    build: 
+      context: .
+      platforms:
+        - linux/arm64
     ports:
-      - "5000:5000"
+      - "8080:8080"
     env_file:
       - .env
+      - aws/aws.env
     restart: unless-stopped

--- a/middleware.py
+++ b/middleware.py
@@ -9,7 +9,7 @@ CORS(app)  # Permite acesso de qualquer origem
 
 # Configuração do logging
 logging.basicConfig(
-    filename='app.log',  # Nome do arquivo de log
+    filename='/dev/stdout',  # Nome do arquivo de log
     level=logging.DEBUG,  # Nível de log
     format='%(asctime)s - %(levelname)s - %(message)s'  # Formato da mensagem
 )
@@ -56,4 +56,4 @@ def test_route():
 
 if __name__ == '__main__':
     print('\n\n\nTESTE0\n\n\n')
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=8080, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 flask-cors
 requests
+python-dotenv


### PR DESCRIPTION
- No ambiente de nuvem da UTFPR (AWS/ECS) adotamos por padrão a arquitetura ARM64.
- Para efeito de normalização, abrimos as portas 80, 443 e 8080-8089 para aplicações Web.
- Como os contêineres executam sob um balanceador de carga (AWS ELB) é necessário definir um domínio para que o tráfego vindo da internet possa ser direcionado ao contêiner correto.
- Para que as variáveis de ambiente contidas no arquivo `.env` sejam usadas pelo Python é necessário incluir o módulo `python-dotenv`. Isto pode ser dispensado se a definição das variáveis de ambiente for feito diretamente na definição da tarefa (`aws/middleware.json`). Na verdade, o ideal é armazenar estas variáveis no AWS Secrets Manager ou AWS  Systems Manager de onde o ECS as carregará automaticamente.
- O arquivo deploy.sh carrega a imagem no ECR (registro de contêineres da AWS), mas para isso é necessário que o usuário tenha permissões específicas. Em algum momento, possivelmente em breve, implementaremos um procedimento que permitirá ao usuário final carregar as suas imagens no ECR e reiniciar os contêineres no ECS.
- Recomendo, para melhor desempenho, usar um servidor Web que suporte o protocolo HTTP/2, procurando desde já um que tenha grau de produção. No momento trata-se apenas de um protótipo, mas uma vez exposta na Internet, será mandatório que todos os componentes da aplicação tenham grau de produção.

Para acessar a aplicação, por exemplo:
https://lucas-santana-middleware.ct.utfpr.edu.br/health

Esta URL pode ser alterada de acordo com a necessidade, embora haja certas condicionantes.
